### PR TITLE
fix: run fzf bindings through bash, not the login shell

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -79,7 +79,7 @@ function M.run_with(cwd)
 		.. [=[
         RG_PREFIX='rg --column --line-number --no-heading --color=always --smart-case'
         PREVIEW='bat --color=always --highlight-line={2} {1}'
-        fzf --ansi --disabled --multi \
+        fzf --ansi --disabled --multi --with-shell 'bash -c' \
             --bind "start:reload:${RG_PREFIX} {q}" \
             --bind "change:reload:sleep 0.1; ${RG_PREFIX} {q} || true" \
             --bind "${TOGGLE_KEY}:transform:[[ ! \${FZF_PROMPT} =~ ripgrep ]] &&


### PR DESCRIPTION
Fixes #2.

`fzf` runs `execute` and `transform` bindings through `$SHELL`, not through the shell that launched fzf. `M.run_with` spawns fzf via `Command("bash")`, but that only sets the shell for the outer command — the `transform` action still reaches the user's login shell.

The mode toggle binding is bash:

```sh
[[ ! ${FZF_PROMPT} =~ ripgrep ]] && echo '...' || echo '...'
```

fish cannot parse it:

```
fish: Variables cannot be bracketed. In fish, please use {$FZF_PROMPT}.
[[ ! ${FZF_PROMPT} =~ ripgrep ]] && echo A || echo B
      ^
```

The `transform` action then returns nothing, so no fzf action runs. The prompt stays on `1. ripgrep> ` and the toggle key looks dead, with no error shown. That matches the reports in #2, where the key works under bash and not under fish, and it is why changing `toggle_mode_key` does not help.

## Reproduction

Running the exact command `M.run_with` builds, with nothing else changed:

```
SHELL=/bin/bash      -> prompt after toggle key: 2. fzf>
SHELL=/usr/bin/fish  -> prompt after toggle key: unchanged
```

## Fix

Pin the child shell for this one fzf call, so the binding no longer depends on the user's login shell:

```diff
-        fzf --ansi --disabled --multi \
+        fzf --ansi --disabled --multi --with-shell 'bash -c' \
```

`--with-shell` takes the command *and* its flags — the default is `$SHELL -c` — so the `-c` is required. `--with-shell bash` alone makes fzf treat the binding as a filename.

`bash` is already a documented requirement of this plugin, so this adds no new dependency. It does require fzf >= 0.51, which introduced `--with-shell`. If you would rather not raise the fzf floor, the alternative is rewriting the binding in POSIX `sh` (`case` and `test` instead of `[[ ]]` and `=~`); happy to send that version instead.

## Verified on

yazi 26.8.15, fzf 0.74.3, fish 4.x — toggle works under both bash and fish after the change.