### PR TITLE
fix: parse filenames containing : and %

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -80,7 +80,7 @@ function M.run_with(cwd)
 		.. " DISPLAY_TOGGLE_KEY="
 		.. ya.quote(format_key_for_display(ss.toggle_mode_key))
 		.. [=[
-        RG_PREFIX=$'rg --column --line-number --no-heading --color=always --smart-case --field-match-separator \x1f\x1e\x1f'
+        RG_PREFIX=$'rg --column --line-number --no-heading --color=always --smart-case --field-match-separator \x1f:\x1e'
         PREVIEW='bat --color=always --highlight-line={2} -- {1}'
         fzf --ansi --disabled --multi \
             --bind "start:reload:${RG_PREFIX} {q}" \
@@ -90,8 +90,8 @@ function M.run_with(cwd)
                    echo 'unbind(change)+change-prompt(2. fzf> )+enable-search+reload:${RG_PREFIX} \"\" || true'" \
             --color "hl:-1:underline,hl+:-1:underline:reverse" \
             --prompt '1. ripgrep> ' \
-            --delimiter '\x1f\x1e\x1f' \
-            --with-nth '{1}:{2}:{3}:{4}' \
+            --delimiter '\x1f:\x1e' \
+            --nth '4..' \
             --header "${DISPLAY_TOGGLE_KEY}: Switch between ripgrep/fzf" \
             --preview "${PREVIEW}" \
             --preview-window 'up,60%,~3,+{2}+3/2'
@@ -112,7 +112,7 @@ function M.run_with(cwd)
 	return output.stdout, nil
 end
 
-local field_sep = "\31\30\31"
+local field_sep = "\31:\30"
 
 function M.split_results(cwd, output)
 	local t = {}

--- a/main.lua
+++ b/main.lua
@@ -91,10 +91,10 @@ function M.run_with(cwd)
             --color "hl:-1:underline,hl+:-1:underline:reverse" \
             --prompt '1. ripgrep> ' \
             --delimiter '\x1f\x1e\x1f' \
+            --with-nth '{1}:{2}:{3}:{4}' \
             --header "${DISPLAY_TOGGLE_KEY}: Switch between ripgrep/fzf" \
             --preview "${PREVIEW}" \
-            --preview-window 'up,60%,~3,+{2}+3/2' \
-            --nth '4..'
+            --preview-window 'up,60%,~3,+{2}+3/2'
         ]=]
 	local child, err =
 		Command("bash"):arg({ "-c", cmd_args }):cwd(tostring(cwd)):stdin(Command.INHERIT):stdout(Command.PIPED):spawn()

--- a/main.lua
+++ b/main.lua
@@ -59,7 +59,10 @@ function M:entry()
 	end
 	local file_args = {}
 	for i, result in ipairs(results) do
-		local arg = string.gsub(ss.file_arg_format, "{file}", ya.quote(tostring(result[1])))
+		local quoted_file = ya.quote(tostring(result[1]))
+		local arg = string.gsub(ss.file_arg_format, "{file}", function()
+			return quoted_file
+		end)
 		arg = string.gsub(arg, "{row}", tostring(result[2]))
 		arg = string.gsub(arg, "{col}", tostring(result[3]))
 		file_args[i] = arg
@@ -77,7 +80,7 @@ function M.run_with(cwd)
 		.. " DISPLAY_TOGGLE_KEY="
 		.. ya.quote(format_key_for_display(ss.toggle_mode_key))
 		.. [=[
-        RG_PREFIX='rg --column --line-number --no-heading --color=always --smart-case'
+        RG_PREFIX=$'rg --column --line-number --no-heading --color=always --smart-case --field-match-separator \x1f\x1e\x1f'
         PREVIEW='bat --color=always --highlight-line={2} {1}'
         fzf --ansi --disabled --multi \
             --bind "start:reload:${RG_PREFIX} {q}" \
@@ -87,11 +90,11 @@ function M.run_with(cwd)
                    echo 'unbind(change)+change-prompt(2. fzf> )+enable-search+reload:${RG_PREFIX} \"\" || true'" \
             --color "hl:-1:underline,hl+:-1:underline:reverse" \
             --prompt '1. ripgrep> ' \
-            --delimiter : \
+            --delimiter '\x1f\x1e\x1f' \
             --header "${DISPLAY_TOGGLE_KEY}: Switch between ripgrep/fzf" \
             --preview "${PREVIEW}" \
             --preview-window 'up,60%,~3,+{2}+3/2' \
-            --nth '3..'
+            --nth '4..'
         ]=]
 	local child, err =
 		Command("bash"):arg({ "-c", cmd_args }):cwd(tostring(cwd)):stdin(Command.INHERIT):stdout(Command.PIPED):spawn()
@@ -109,15 +112,19 @@ function M.run_with(cwd)
 	return output.stdout, nil
 end
 
+local field_sep = "\31\30\31"
+
 function M.split_results(cwd, output)
 	local t = {}
 	for line in output:gmatch("[^\r\n]+") do
-		local file, row, col = (string.gmatch(line, "(..-):(%d+):(%d+):"))()
-		local u = Url(file)
-		if u.is_absolute then
-			t[#t + 1] = { u, row, col }
-		else
-			t[#t + 1] = { cwd:join(u), row, col }
+		local file, row, col = line:match("^(.-)" .. field_sep .. "(%d+)" .. field_sep .. "(%d+)" .. field_sep)
+		if file then
+			local u = Url(file)
+			t[#t + 1] = {
+				u.is_absolute and u or cwd:join(u),
+				row,
+				col,
+			}
 		end
 	end
 	return t

--- a/main.lua
+++ b/main.lua
@@ -81,7 +81,7 @@ function M.run_with(cwd)
 		.. ya.quote(format_key_for_display(ss.toggle_mode_key))
 		.. [=[
         RG_PREFIX=$'rg --column --line-number --no-heading --color=always --smart-case --field-match-separator \x1f\x1e\x1f'
-        PREVIEW='bat --color=always --highlight-line={2} {1}'
+        PREVIEW='bat --color=always --highlight-line={2} -- {1}'
         fzf --ansi --disabled --multi \
             --bind "start:reload:${RG_PREFIX} {q}" \
             --bind "change:reload:sleep 0.1; ${RG_PREFIX} {q} || true" \


### PR DESCRIPTION
## Summary
- Stop treating `%` in `{file}` as a Lua `gsub` replacement escape.
- Delimit rg/fzf/Lua fields with `\x1f\x1e\x1f` instead of `:`, so names like `foo:bar.txt` parse correctly.
- Display results as `file:line:col:text` via fzf `--with-nth` while keeping the internal delimiter for parsing.

## Test plan
- Search fixture files whose names contain `:`, `%`, spaces, quotes, `$`, `#`, `--`, unicode, and nested `sub:dir/nested:file.txt`.
- Confirm fzf lists `file:line:col:text` instead of glued fields.
- Open results in Helix and confirm `{file}:{row}:{col}` lands on the match.

Amp-Thread-ID: https://ampcode.com/threads/T-01a05b3f-6361-76d9-9f3e-a7a970208500